### PR TITLE
Fix accent color

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -4,6 +4,7 @@
   "name": "Analog Labs",
   "colors": {
     "primary": "#ff5e2b",
+    "accent": "#ff5e2b",
     "light": "#ffffff",
     "dark": "#000000"
   },


### PR DESCRIPTION
## Summary
- add `accent` color setting (#ff5e2b)

## Testing
- `mintlify --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849248e8eec8333ac7c6939248ed076