### PR TITLE
Fix logo theme mapping

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -44,8 +44,8 @@
     }
   },
   "logo": {
-    "light": "/logo/analog-labs-logo-light.png",
-    "dark": "/logo/analog-labs-logo-dark.png"
+    "light": "/logo/analog-labs-logo-dark.png",
+    "dark": "/logo/analog-labs-logo-light.png"
   },
   "navbar": {
     "links": [


### PR DESCRIPTION
## Summary
- swap the dark and light logo references so the correct logo shows based on the theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849f880327883338dc5a4cc03cc38b2